### PR TITLE
Fixed build issues on Raspberry Pi 3 running Raspberry Pi OS 10

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define PAGE_SIZE (4*1024)
 
-void *mapmem(unsigned base, unsigned size)
+void *mapmem(uint32_t base, uint32_t size)
 {
     int mem_fd;
     unsigned offset = base % PAGE_SIZE;
@@ -64,18 +64,16 @@ void *mapmem(unsigned base, unsigned size)
         exit (-1);
     }
     close(mem_fd);
-    return (char *)mem + offset;
+    return mem + offset;
 }
 
-void *unmapmem(void *addr, unsigned size)
+void unmapmem(void *addr, uint32_t size)
 {
     int s = munmap(addr, size);
     if (s != 0) {
         printf("munmap error %d\n", s);
         exit (-1);
     }
-
-    return NULL;
 }
 
 /*

--- a/mailbox.h
+++ b/mailbox.h
@@ -88,15 +88,15 @@ uint32_t mem_unlock(int file_desc, uint32_t handle);
 /** @brief open a read/write/sync file at the start of page where base is located and make the file size
  *  @param base - the base address of the file
  *  @param size - the size of the file
- *  @return (uint8_t *) - pointer to the spot in memory at the address base
+ *  @return (void*) - pointer to the spot in memory at the address base
  */
-uint8_t *mapmem(uint32_t base, uint32_t size);
+void *mapmem(uint32_t base, uint32_t size);
 /** @brief call munmap on *addr and return NULL. Call exit if it fails
  *  @param addr - the address to pass to munmap
  *  @param size - the size to pass to munmap
  *  @return Void.
  */
-void unmapmem(uint8_t *addr, uint32_t size);
+void unmapmem(void *addr, uint32_t size);
 
 /** @brief write an array out to mbox_proptery.
  *  @param file_desc - the number returned by mbox_open

--- a/wspr.cpp
+++ b/wspr.cpp
@@ -140,6 +140,7 @@ extern "C" {
 #ifdef RPI4
 #define PERI_BASE_PHYS 0xfe000000
 #define MEM_FLAG 0x04
+#else
 #ifdef RPI23
 #define PERI_BASE_PHYS 0x3f000000
 #define MEM_FLAG 0x04


### PR DESCRIPTION
GCC: gcc / g++ (Raspbian 8.3.0-6+rpi1) 8.3.0
Issues:
- Wrong parameter types lead to build failure
- Missing `#else` leads to build failure on Raspberry Pi 2 and Raspberry Pi 3